### PR TITLE
feat: optional existence checking

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,6 +66,10 @@ The `options` property is specific to the chosen transporter. The <strong>GCloud
     <td>If <code>false</code>, topics and subscriptions will not be created, only validated</td>
   </tr>
   <tr>
+    <td><code>checkExistence</code></td>
+    <td>If <code>false</code>, topics and subscriptions will not be checked, only used. This only applies when <code>init</code> is <code>false</code></td>
+  </tr>
+  <tr>
     <td><code>client</code></td>
     <td>Additional client options (read more <a href="https://googleapis.dev/nodejs/pubsub/latest/global.html#ClientConfig" rel="nofollow" target="_blank">here</a>)</td>
   </tr>

--- a/lib/gc-pubsub.constants.ts
+++ b/lib/gc-pubsub.constants.ts
@@ -5,4 +5,5 @@ export const GC_PUBSUB_DEFAULT_SUBSCRIBER_CONFIG = {};
 export const GC_PUBSUB_DEFAULT_CLIENT_CONFIG = {};
 export const GC_PUBSUB_DEFAULT_NO_ACK = true;
 export const GC_PUBSUB_DEFAULT_INIT = true;
+export const GC_PUBSUB_DEFAULT_CHECK_EXISTENCE = true;
 export const ALREADY_EXISTS = 6;

--- a/lib/gc-pubsub.interface.ts
+++ b/lib/gc-pubsub.interface.ts
@@ -11,6 +11,7 @@ export interface GCPubSubOptions {
   replySubscription?: string;
   noAck?: boolean;
   init?: boolean
+  checkExistence?: boolean;
   publisher?: PublishOptions;
   subscriber?: SubscriberOptions;
   serializer?: Serializer;


### PR DESCRIPTION
Added a new attribute called `checkExistence` that allows users to decide whether they want the existence check process for topics and subscriptions when creating the GCP Pub/Sub client instances.

This is closely related to the recent inclusion of the `init` parameter.

This change will helps users to accomplish two actions:
1. Avoid requiring additional GCP service account permissions to check existence.
2. Improve the speed when launching their projects due to the lack of existence checking.