### PR TITLE
Feat/modify to follow nestjs and googleapis standard

### DIFF
--- a/lib/gc-message.builder.spec.ts
+++ b/lib/gc-message.builder.spec.ts
@@ -1,0 +1,33 @@
+import { expect } from 'chai';
+import { GCPubSubMessage, GCPubSubMessageBuilder } from './gc-message.builder';
+
+describe('GCPubSubMessageBuilder', () => {
+  const data = { id: 1, name: 'John Doe' };
+  const attributes = { category: 'person' };
+  const orderingKey = '1';
+
+  it('should build with valid data only', () => {
+    const message = new GCPubSubMessageBuilder('data').build();
+    expect(message).to.be.instanceOf(GCPubSubMessage);
+    expect(message.json).to.equal('data');
+    expect(message.attributes).to.be.undefined;
+    expect(message.orderingKey).to.be.undefined;
+  });
+
+  it('should throw an error if data is missing', () => {
+    const builder = new GCPubSubMessageBuilder();
+    builder.setAttributes(attributes).setOrderingKey(orderingKey);
+
+    expect(() => builder.build()).to.throw('Missing Data');
+  });
+
+  it('should create a new GCPubSubMessage with the correct parameters', () => {
+    const builder = new GCPubSubMessageBuilder(data, attributes, orderingKey);
+
+    const message = builder.build();
+
+    expect(message.json).to.deep.equal(data);
+    expect(message.attributes).to.deep.equal(attributes);
+    expect(message.orderingKey).to.equal(orderingKey);
+  });
+});

--- a/lib/gc-message.builder.ts
+++ b/lib/gc-message.builder.ts
@@ -1,0 +1,38 @@
+import { PubSub } from '@google-cloud/pubsub';
+
+export class GCPubSubMessage<TData = any, TAttrs = any> {
+  constructor(
+    public readonly json: TData,
+    public readonly attributes: TAttrs,
+    public readonly orderingKey: string | undefined,
+  ) {}
+}
+
+export class GCPubSubMessageBuilder<TData, TAttrs = any> {
+  private attributes?: TAttrs;
+  private orderingKey?: string;
+  constructor(
+    private data?: TData,
+    attributes?: TAttrs,
+    orderingKey?: string,
+  ) {}
+
+  public setAttributes(attributes: TAttrs) {
+    this.attributes = attributes;
+    return this;
+  }
+
+  public setData(data: TData) {
+    this.data = data;
+    return this;
+  }
+
+  public setOrderingKey(orderingKey: string) {
+    this.orderingKey = orderingKey;
+    return this;
+  }
+
+  public build() {
+    return new GCPubSubMessage(this.data, this.attributes, this.orderingKey);
+  }
+}

--- a/lib/gc-message.builder.ts
+++ b/lib/gc-message.builder.ts
@@ -1,4 +1,5 @@
 import { PubSub } from '@google-cloud/pubsub';
+import { RpcException } from '@nestjs/microservices';
 
 export class GCPubSubMessage<TData = any, TAttrs = any> {
   constructor(
@@ -8,13 +9,11 @@ export class GCPubSubMessage<TData = any, TAttrs = any> {
   ) {}
 }
 
-export class GCPubSubMessageBuilder<TData, TAttrs = any> {
-  private attributes?: TAttrs;
-  private orderingKey?: string;
+export class GCPubSubMessageBuilder<TData, TAttrs extends {}> {
   constructor(
     private data?: TData,
-    attributes?: TAttrs,
-    orderingKey?: string,
+    private attributes?: Partial<TAttrs>,
+    private orderingKey?: string,
   ) {}
 
   public setAttributes(attributes: TAttrs) {
@@ -33,6 +32,11 @@ export class GCPubSubMessageBuilder<TData, TAttrs = any> {
   }
 
   public build() {
-    return new GCPubSubMessage(this.data, this.attributes, this.orderingKey);
+    if (!this.data) throw new Error('Missing Data');
+    return new GCPubSubMessage<TData, TAttrs>(
+      this.data,
+      this.attributes as TAttrs,
+      this.orderingKey,
+    );
   }
 }

--- a/lib/gc-message.serializer.spec.ts
+++ b/lib/gc-message.serializer.spec.ts
@@ -1,0 +1,115 @@
+import { expect } from 'chai';
+import { GCPubSubMessageBuilder } from './gc-message.builder';
+import { GCPubSubMessageSerializer } from './gc-message.serializer';
+
+describe('GCPubSubMessageSerializer', () => {
+  let instance: GCPubSubMessageSerializer;
+  beforeEach(() => {
+    instance = new GCPubSubMessageSerializer();
+  });
+  describe('serialize', () => {
+    it('undefined', () => {
+      expect(instance.serialize({ data: undefined })).to.deep.eq({
+        json: undefined,
+        attributes: undefined,
+        orderingKey: undefined,
+      });
+    });
+
+    it('null', () => {
+      expect(instance.serialize({ data: null })).to.deep.eq({
+        json: null,
+        attributes: undefined,
+        orderingKey: undefined,
+      });
+    });
+
+    it('string', () => {
+      expect(instance.serialize({ data: 'string' })).to.deep.eq({
+        json: 'string',
+        attributes: undefined,
+        orderingKey: undefined,
+      });
+    });
+
+    it('number', () => {
+      expect(instance.serialize({ data: 12345 })).to.deep.eq({
+        json: 12345,
+        attributes: undefined,
+        orderingKey: undefined,
+      });
+    });
+
+    it('array', () => {
+      expect(instance.serialize({ data: [1, 2, 3, 4, 5] })).to.deep.eq({
+        json: [1, 2, 3, 4, 5],
+        attributes: undefined,
+        orderingKey: undefined,
+      });
+    });
+
+    it('object', () => {
+      const serObject = { prop: 'value' };
+      expect(instance.serialize({ data: serObject })).to.deep.eq({
+        json: {
+          prop: 'value',
+        },
+        attributes: undefined,
+        orderingKey: undefined,
+      });
+    });
+
+    it('GCPMessage with attributes', () => {
+      const attributes = {
+        key: 'abcde',
+      };
+      const message = new GCPubSubMessageBuilder({
+        value: 'string',
+      })
+        .setAttributes(attributes)
+        .build();
+      expect(instance.serialize({ data: message })).to.deep.eq({
+        json: {
+          value: 'string',
+        },
+        attributes: {
+          key: 'abcde',
+        },
+        orderingKey: undefined,
+      });
+    });
+
+    it('GCPMessage with orderingKey', () => {
+      const orderingKey = 'key';
+      const message = new GCPubSubMessageBuilder({
+        value: 'string',
+      })
+        .setOrderingKey(orderingKey)
+        .build();
+      expect(instance.serialize({ data: message })).to.deep.eq({
+        json: {
+          value: 'string',
+        },
+        orderingKey: 'key',
+        attributes: undefined,
+      });
+    });
+
+    it('GCPMessage with attributes and orderingKey', () => {
+      const orderingKey = 'key';
+      const message = new GCPubSubMessageBuilder({
+        value: 'string',
+      })
+        .setOrderingKey(orderingKey)
+        .setAttributes({ key: 'key' })
+        .build();
+      expect(instance.serialize({ data: message })).to.deep.eq({
+        json: {
+          value: 'string',
+        },
+        orderingKey: 'key',
+        attributes: { key: 'key' },
+      });
+    });
+  });
+});

--- a/lib/gc-message.serializer.spec.ts
+++ b/lib/gc-message.serializer.spec.ts
@@ -28,7 +28,6 @@ describe('GCPubSubMessageSerializer', () => {
     const msg = new GCPubSubMessageBuilder(data)
       .setAttributes(attributes)
       .build();
-    console.log(msg);
     const packet = { data: msg, pattern: 'test' };
     const message = new GCPubSubMessage(data, attributes, undefined);
 

--- a/lib/gc-message.serializer.ts
+++ b/lib/gc-message.serializer.ts
@@ -7,10 +7,15 @@ export class GCPubSubMessageSerializer
   constructor() {}
 
   serialize(packet: ReadPacket<any> | any): GCPubSubMessage<any, any> {
-    const message =
-      packet.data && packet.data instanceof GCPubSubMessage
-        ? (packet.data as GCPubSubMessage)
-        : new GCPubSubMessageBuilder(packet.data).build();
-    return { ...message };
+    let message: GCPubSubMessage;
+
+    if (packet.data instanceof GCPubSubMessage) {
+      message = packet.data as GCPubSubMessage;
+      console.log(message);
+    } else {
+      message = new GCPubSubMessageBuilder(packet.data).build();
+    }
+
+    return message;
   }
 }

--- a/lib/gc-message.serializer.ts
+++ b/lib/gc-message.serializer.ts
@@ -11,7 +11,6 @@ export class GCPubSubMessageSerializer
 
     if (packet.data instanceof GCPubSubMessage) {
       message = packet.data as GCPubSubMessage;
-      console.log(message);
     } else {
       message = new GCPubSubMessageBuilder(packet.data).build();
     }

--- a/lib/gc-message.serializer.ts
+++ b/lib/gc-message.serializer.ts
@@ -1,0 +1,16 @@
+import { ReadPacket, Serializer } from '@nestjs/microservices';
+import { GCPubSubMessage, GCPubSubMessageBuilder } from './gc-message.builder';
+
+export class GCPubSubMessageSerializer
+  implements Serializer<ReadPacket, GCPubSubMessage>
+{
+  constructor() {}
+
+  serialize(packet: ReadPacket<any> | any): GCPubSubMessage<any, any> {
+    const message =
+      packet.data && packet.data instanceof GCPubSubMessage
+        ? (packet.data as GCPubSubMessage)
+        : new GCPubSubMessageBuilder(packet.data).build();
+    return { ...message };
+  }
+}

--- a/lib/gc-pubsub.client.spec.ts
+++ b/lib/gc-pubsub.client.spec.ts
@@ -148,68 +148,47 @@ describe('GCPubSubClient', () => {
   });
 
   describe('publish', () => {
-    describe('useAttributes=false', () => {
-      const pattern = 'test';
-      const msg = { pattern, data: 'data' };
-
-      beforeEach(() => {
-        client = getInstance({
-          replyTopic: 'replyTopic',
-          replySubscription: 'replySubcription',
-        });
-
-        (client as any).topic = topicMock;
+    beforeEach(() => {
+      client = getInstance({
+        replyTopic: 'replyTopic',
+        replySubscription: 'replySubcription',
       });
 
-      it('should send message to a proper topic', () => {
-        client['publish'](msg, () => {
-          expect(topicMock.publishMessage.called).to.be.true;
-          expect(topicMock.publishMessage.getCall(0).args[0].json).to.be.eql(
-            msg,
-          );
-        });
-      });
-
-      it('should remove listener from routing map on dispose', () => {
-        client['publish'](msg, () => ({}))();
-
-        expect(client['routingMap'].size).to.be.eq(0);
-      });
-
-      it('should call callback on error', () => {
-        const callback = sandbox.spy();
-        sinon.stub(client, 'assignPacketId' as any).callsFake(() => {
-          throw new Error();
-        });
-        client['publish'](msg, callback);
-        expect(callback.called).to.be.true;
-        expect(callback.getCall(0).args[0].err).to.be.instanceof(Error);
-      });
+      (client as any).topic = topicMock;
+    });
+    const pattern = 'test';
+    const msg = { pattern, data: 'data' };
+    it('should send message to a proper topic', () => {
+      client['publish'](msg, () => {});
+      const message = topicMock.publishMessage.getCall(0).args[0];
+      expect(topicMock.publishMessage.called).to.be.true;
+      expect(message.json).to.be.eql(msg.data);
     });
 
-    describe('useAttributes=true', () => {
-      const pattern = 'test';
-      const msg = { pattern, data: 'data' };
+    it('should remove listener from routing map on dispose', () => {
+      client['publish'](msg, () => ({}))();
 
-      beforeEach(() => {
-        client = getInstance({
-          replyTopic: 'replyTopic',
-          replySubscription: 'replySubcription',
-          useAttributes: true,
-        });
+      expect(client['routingMap'].size).to.be.eq(0);
+    });
 
-        (client as any).topic = topicMock;
+    it('should call callback on error', () => {
+      const callback = sandbox.spy();
+      sinon.stub(client, 'assignPacketId' as any).callsFake(() => {
+        throw new Error();
       });
+      client['publish'](msg, callback);
+      expect(callback.called).to.be.true;
+      expect(callback.getCall(0).args[0].err).to.be.instanceof(Error);
+    });
 
-      it('should send message to a proper topic', () => {
-        client['publish'](msg, () => {});
+    it('should send message to a proper topic', () => {
+      client['publish'](msg, () => {});
 
-        expect(topicMock.publishMessage.called).to.be.true;
-        const message = topicMock.publishMessage.getCall(0).args[0];
-        expect(message.json).to.be.eql(msg.data);
-        expect(message.attributes.pattern).to.be.eql(pattern);
-        expect(message.attributes.id).to.be.not.empty;
-      });
+      expect(topicMock.publishMessage.called).to.be.true;
+      const message = topicMock.publishMessage.getCall(0).args[0];
+      expect(message.json).to.be.eql(msg.data);
+      expect(message.attributes.pattern).to.be.eql(pattern);
+      expect(message.attributes.id).to.be.not.empty;
     });
   });
 
@@ -302,69 +281,56 @@ describe('GCPubSubClient', () => {
   });
 
   describe('dispatchEvent', () => {
-    describe('useAttributes=false', () => {
-      const msg = { pattern: 'pattern', data: 'data' };
+    const msg = { pattern: 'pattern', data: 'data' };
 
-      beforeEach(() => {
-        client = getInstance({
-          replyTopic: 'replyTopic',
-          replySubscription: 'replySubcription',
-        });
-        (client as any).topic = topicMock;
+    beforeEach(() => {
+      client = getInstance({
+        replyTopic: 'replyTopic',
+        replySubscription: 'replySubcription',
       });
-
-      it('should publish packet', async () => {
-        await client['dispatchEvent'](msg);
-        expect(topicMock.publishMessage.called).to.be.true;
-      });
-
-      it('should publish packet with proper data', async () => {
-        await client['dispatchEvent'](msg);
-        expect(topicMock.publishMessage.getCall(0).args[0].json).to.be.eql(msg);
-      });
-
-      it('should throw error', async () => {
-        topicMock.publishMessage.callsFake((a: any, b: any, c: any, d: any) =>
-          d(new Error()),
-        );
-        client['dispatchEvent'](msg).catch((err) =>
-          expect(err).to.be.instanceOf(Error),
-        );
-      });
+      (client as any).topic = topicMock;
     });
 
-    describe('useAttributes=true', () => {
-      const msg = { pattern: 'pattern', data: 'data' };
+    it('should publish packet', async () => {
+      await client['dispatchEvent'](msg);
+      expect(topicMock.publishMessage.called).to.be.true;
+    });
 
-      beforeEach(() => {
-        client = getInstance({
-          replyTopic: 'replyTopic',
-          replySubscription: 'replySubcription',
-          useAttributes: true,
-        });
-        (client as any).topic = topicMock;
-      });
+    it('should publish packet with proper data', async () => {
+      await client['dispatchEvent'](msg);
+      expect(topicMock.publishMessage.getCall(0).args[0].json).to.be.eql(
+        msg.data,
+      );
+    });
 
-      it('should publish packet', async () => {
-        await client['dispatchEvent'](msg);
-        expect(topicMock.publishMessage.called).to.be.true;
-      });
+    it('should throw error', async () => {
+      topicMock.publishMessage.callsFake((a: any, b: any, c: any, d: any) =>
+        d(new Error()),
+      );
+      client['dispatchEvent'](msg).catch((err) =>
+        expect(err).to.be.instanceOf(Error),
+      );
+    });
 
-      it('should publish packet with proper data', async () => {
-        await client['dispatchEvent'](msg);
-        const message = topicMock.publishMessage.getCall(0).args[0];
-        expect(message.json).to.be.eql(msg.data);
-        expect(message.attributes.pattern).to.be.eql(msg.pattern);
-      });
+    it('should publish packet', async () => {
+      await client['dispatchEvent'](msg);
+      expect(topicMock.publishMessage.called).to.be.true;
+    });
 
-      it('should throw error', async () => {
-        topicMock.publishMessage.callsFake((a: any, b: any, c: any, d: any) =>
-          d(new Error()),
-        );
-        client['dispatchEvent'](msg).catch((err) =>
-          expect(err).to.be.instanceOf(Error),
-        );
-      });
+    it('should publish packet with proper data', async () => {
+      await client['dispatchEvent'](msg);
+      const message = topicMock.publishMessage.getCall(0).args[0];
+      expect(message.json).to.be.eql(msg.data);
+      expect(message.attributes.pattern).to.be.eql(msg.pattern);
+    });
+
+    it('should throw error', async () => {
+      topicMock.publishMessage.callsFake((a: any, b: any, c: any, d: any) =>
+        d(new Error()),
+      );
+      client['dispatchEvent'](msg).catch((err) =>
+        expect(err).to.be.instanceOf(Error),
+      );
     });
   });
 

--- a/lib/gc-pubsub.interface.ts
+++ b/lib/gc-pubsub.interface.ts
@@ -1,4 +1,4 @@
-import { ClientConfig } from '@google-cloud/pubsub';
+import { ClientConfig, CreateSubscriptionOptions } from '@google-cloud/pubsub';
 import { Deserializer, Serializer } from '@nestjs/microservices';
 import { PublishOptions } from '@google-cloud/pubsub/build/src/publisher';
 import { SubscriberOptions } from '@google-cloud/pubsub/build/src/subscriber';
@@ -11,10 +11,10 @@ export interface GCPubSubOptions {
   replySubscription?: string;
   noAck?: boolean;
   init?: boolean;
-  useAttributes?: boolean;
   checkExistence?: boolean;
   publisher?: PublishOptions;
   subscriber?: SubscriberOptions;
   serializer?: Serializer;
   deserializer?: Deserializer;
+  createSubscriptionOptions?: CreateSubscriptionOptions;
 }

--- a/lib/gc-pubsub.server.spec.ts
+++ b/lib/gc-pubsub.server.spec.ts
@@ -5,6 +5,7 @@ import { NO_MESSAGE_HANDLER } from '@nestjs/microservices/constants';
 import { BaseRpcContext } from '@nestjs/microservices/ctx-host/base-rpc.context';
 import { ALREADY_EXISTS } from './gc-pubsub.constants';
 import { GCPubSubOptions } from './gc-pubsub.interface';
+import { CreateSubscriptionOptions, Message } from '@google-cloud/pubsub';
 
 describe('GCPubSubServer', () => {
   let server: GCPubSubServer;
@@ -50,6 +51,68 @@ describe('GCPubSubServer', () => {
 
       it('should call "subscription.on" twice', async () => {
         expect(subscriptionMock.on.callCount).to.eq(2);
+      });
+    });
+
+    describe('when createSubscriptionOptions is provided', () => {
+      const mockCreateSubscriptionOptions: CreateSubscriptionOptions = {
+        messageRetentionDuration: {
+          seconds: 604800, // 7 days
+        },
+        pushEndpoint: 'https://example.com/push',
+        oidcToken: {
+          serviceAccountEmail: 'example@example.com',
+          audience: 'https://example.com',
+        },
+        topic: 'projects/my-project/topics/my-topic',
+        pushConfig: {
+          pushEndpoint: 'https://example.com/push',
+        },
+        ackDeadlineSeconds: 60,
+        retainAckedMessages: true,
+        labels: {
+          env: 'dev',
+          version: '1.0.0',
+        },
+        enableMessageOrdering: false,
+        expirationPolicy: {
+          ttl: {
+            seconds: 86400, // 1 day
+          },
+        },
+        filter: 'attribute.type = "order"',
+        deadLetterPolicy: {
+          deadLetterTopic: 'projects/my-project/topics/my-dead-letter-topic',
+          maxDeliveryAttempts: 5,
+        },
+        retryPolicy: {
+          minimumBackoff: {
+            seconds: 10,
+          },
+          maximumBackoff: {
+            seconds: 300,
+          },
+        },
+        detached: false,
+        enableExactlyOnceDelivery: true,
+        topicMessageRetentionDuration: {
+          seconds: 2592000, // 30 days
+        },
+        state: 'ACTIVE',
+      };
+
+      beforeEach(async () => {
+        server = getInstance({
+          createSubscriptionOptions: mockCreateSubscriptionOptions,
+        });
+        await server.listen(() => {});
+      });
+      it('should call "subscription.create" with argument', async () => {
+        // Verify that subscription.create() was called with the correct arguments
+        expect(subscriptionMock.create.calledOnce).to.be.true;
+        expect(
+          subscriptionMock.create.calledWith(mockCreateSubscriptionOptions),
+        ).to.be.true;
       });
     });
 
@@ -107,9 +170,26 @@ describe('GCPubSubServer', () => {
 
   describe('handleMessage', () => {
     const msg = {
-      pattern: 'test',
       data: 'tests',
-      id: '3',
+    };
+
+    const messageOptions: Message = {
+      ackId: 'id',
+      // @ts-ignore
+      publishTime: new Date(),
+      attributes: {
+        replyTo: 'replyTo',
+        id: '3',
+        pattern: 'test',
+        clientId: '4',
+      },
+      id: 'id',
+      received: 0,
+      deliveryAttempt: 1,
+      ack: () => {},
+      modAck: () => {},
+      nack: () => {},
+      data: Buffer.from(JSON.stringify(msg)),
     };
 
     beforeEach(async () => {
@@ -118,31 +198,18 @@ describe('GCPubSubServer', () => {
     });
 
     it('should send NO_MESSAGE_HANDLER error if key does not exists in handlers object', async () => {
-      await server.handleMessage({
-        ackId: 'id',
-        // @ts-ignore
-        publishTime: new Date(),
-        attributes: {
-          replyTo: 'replyTo',
-        },
-        id: 'id',
-        received: 0,
-        deliveryAttempt: 1,
-        ack: () => {},
-        modAck: () => {},
-        nack: () => {},
-        data: Buffer.from(JSON.stringify(msg)),
-      });
+      await server.handleMessage(messageOptions);
 
       expect(
         topicMock.publishMessage.calledWith({
           json: {
-            id: msg.id,
+            id: messageOptions.attributes.id,
             status: 'error',
             err: NO_MESSAGE_HANDLER,
           },
           attributes: {
-            id: msg.id,
+            id: messageOptions.attributes.id,
+            ...messageOptions.attributes,
           },
         }),
       ).to.be.true;
@@ -151,21 +218,9 @@ describe('GCPubSubServer', () => {
     it('should call handler if exists in handlers object', async () => {
       const handler = sinon.spy();
       (server as any).messageHandlers = objectToMap({
-        [msg.pattern]: handler as any,
+        [messageOptions.attributes.pattern]: handler as any,
       });
-      await server.handleMessage({
-        ackId: 'id',
-        // @ts-ignore
-        publishTime: new Date(),
-        attributes: {},
-        id: 'id',
-        received: 0,
-        deliveryAttempt: 1,
-        ack: () => {},
-        modAck: () => {},
-        nack: () => {},
-        data: Buffer.from(JSON.stringify(msg)),
-      });
+      await server.handleMessage(messageOptions);
       expect(handler.calledOnce).to.be.true;
     });
   });


### PR DESCRIPTION
- send all metadata such as replyTo, id, clientId and pattern via attributes
- ability to pass in attributes and ordering key with message builder and is parsed with a custom serializer
- server abides to clients standards to read metadata from attributes
- server response to message with attributes attached to the response