### PR TITLE
Scoped env

### DIFF
--- a/lib/gc-pubsub.client.spec.ts
+++ b/lib/gc-pubsub.client.spec.ts
@@ -20,6 +20,27 @@ describe('GCPubSubClient', () => {
     sandbox.restore();
   });
 
+  describe('constructor', () => {
+    describe('when the scopedEnvKey is defined', () => {
+      beforeEach(() => {
+        client = getInstance({
+          topic: 'topic',
+          replyTopic: 'replyTopic',
+          replySubscription: 'replySubscription',
+          scopedEnvKey: 'my-key',
+        });
+      });
+
+      it('should set the scopedEnvKey on topics and subscriptions', () => {
+        expect(client['topicName']).to.be.eq('my-keytopic');
+        expect(client['replyTopicName']).to.be.eq('my-keyreplyTopic');
+        expect(client['replySubscriptionName']).to.be.eq(
+          'my-keyreplySubscription',
+        );
+      });
+    });
+  });
+
   describe('connect', () => {
     describe('when is not connected', () => {
       describe('when check existence is true', () => {

--- a/lib/gc-pubsub.client.ts
+++ b/lib/gc-pubsub.client.ts
@@ -46,6 +46,7 @@ export class GCPubSubClient extends ClientProxy {
   protected replySubscription: Subscription | null = null;
   protected topic: Topic | null = null;
   protected init: boolean;
+  protected readonly scopedEnvKey: string | null;
   protected readonly checkExistence: boolean;
 
   constructor(protected readonly options: GCPubSubOptions) {
@@ -53,7 +54,13 @@ export class GCPubSubClient extends ClientProxy {
 
     this.clientConfig = this.options.client || GC_PUBSUB_DEFAULT_CLIENT_CONFIG;
 
+    this.scopedEnvKey = this.options.scopedEnvKey ?? null;
+
     this.topicName = this.options.topic || GC_PUBSUB_DEFAULT_TOPIC;
+
+    if (this.scopedEnvKey) {
+      this.topicName = `${this.scopedEnvKey}${this.topicName}`;
+    }
 
     this.subscriberConfig =
       this.options.subscriber || GC_PUBSUB_DEFAULT_SUBSCRIBER_CONFIG;
@@ -63,7 +70,15 @@ export class GCPubSubClient extends ClientProxy {
 
     this.replyTopicName = this.options.replyTopic;
 
+    if (this.scopedEnvKey) {
+      this.replyTopicName = `${this.scopedEnvKey}${this.replyTopicName}`;
+    }
+
     this.replySubscriptionName = this.options.replySubscription;
+
+    if (this.scopedEnvKey) {
+      this.replySubscriptionName = `${this.scopedEnvKey}${this.replySubscriptionName}`;
+    }
 
     this.noAck = this.options.noAck ?? GC_PUBSUB_DEFAULT_NO_ACK;
     this.init = this.options.init ?? GC_PUBSUB_DEFAULT_INIT;

--- a/lib/gc-pubsub.interface.ts
+++ b/lib/gc-pubsub.interface.ts
@@ -13,6 +13,7 @@ export interface GCPubSubOptions {
   init?: boolean;
   useAttributes?: boolean;
   checkExistence?: boolean;
+  scopedEnvKey?: string | null;
   publisher?: PublishOptions;
   subscriber?: SubscriberOptions;
   serializer?: Serializer;

--- a/lib/gc-pubsub.server.spec.ts
+++ b/lib/gc-pubsub.server.spec.ts
@@ -20,6 +20,21 @@ describe('GCPubSubServer', () => {
     sandbox.restore();
   });
 
+  describe('constructor', () => {
+    describe('when the scopedEnvKey is defined', () => {
+      it('should set the scopedEnvKey on topics and subscriptions', () => {
+        const scopedEnvKey = 'my-key';
+
+        server = getInstance({ scopedEnvKey } as GCPubSubOptions);
+
+        expect(server['topicName']).to.eq(`${scopedEnvKey}default_topic`);
+        expect(server['subscriptionName']).to.eq(
+          `${scopedEnvKey}default_subscription`,
+        );
+      });
+    });
+  });
+
   describe('listen', () => {
     describe('when is check existence is true', () => {
       beforeEach(async () => {
@@ -190,6 +205,24 @@ describe('GCPubSubServer', () => {
           },
         }),
       ).to.be.true;
+    });
+
+    describe('when scopedEnvKey is defined', () => {
+      beforeEach(async () => {
+        server = getInstance({ scopedEnvKey: 'my-key' });
+        await server.listen(() => {});
+      });
+
+      it('should set scopedEnvKey on replyTo', async () => {
+        const message = { test: true };
+        const replyTo = 'test';
+        const correlationId = '0';
+
+        await server.sendMessage(message, replyTo, correlationId);
+        expect(Array.from(server['replyTopics'].values())).to.deep.eq([
+          'my-keytest',
+        ]);
+      });
     });
   });
 

--- a/lib/gc-pubsub.server.ts
+++ b/lib/gc-pubsub.server.ts
@@ -48,6 +48,7 @@ export class GCPubSubServer extends Server implements CustomTransportStrategy {
   protected readonly replyTopics: Set<string>;
   protected readonly init: boolean;
   protected readonly checkExistence: boolean;
+  protected readonly scopedEnvKey: string | null;
 
   protected client: PubSub | null = null;
   protected subscription: Subscription | null = null;
@@ -56,11 +57,19 @@ export class GCPubSubServer extends Server implements CustomTransportStrategy {
     super();
 
     this.clientConfig = this.options.client || GC_PUBSUB_DEFAULT_CLIENT_CONFIG;
-
+    this.scopedEnvKey = this.options.scopedEnvKey ?? null;
     this.topicName = this.options.topic || GC_PUBSUB_DEFAULT_TOPIC;
+
+    if (this.scopedEnvKey) {
+      this.topicName = `${this.scopedEnvKey}${this.topicName}`;
+    }
 
     this.subscriptionName =
       this.options.subscription || GC_PUBSUB_DEFAULT_SUBSCRIPTION;
+
+    if (this.scopedEnvKey) {
+      this.subscriptionName = `${this.scopedEnvKey}${this.subscriptionName}`;
+    }
 
     this.subscriberConfig =
       this.options.subscriber || GC_PUBSUB_DEFAULT_SUBSCRIBER_CONFIG;
@@ -204,6 +213,10 @@ export class GCPubSubServer extends Server implements CustomTransportStrategy {
     const outgoingResponse = this.serializer.serialize(
       message as unknown as OutgoingResponse,
     );
+
+    if (this.scopedEnvKey) {
+      replyTo = `${this.scopedEnvKey}${replyTo}`;
+    }
 
     this.replyTopics.add(replyTo);
 

--- a/tests/e2e/scoped-env-gc-pubsub.spec.ts
+++ b/tests/e2e/scoped-env-gc-pubsub.spec.ts
@@ -1,0 +1,60 @@
+import { INestApplication } from '@nestjs/common';
+import { Test } from '@nestjs/testing';
+import { expect } from 'chai';
+import * as request from 'supertest';
+import { GCPubSubServer } from '../../lib';
+import {
+  GCPubSubScopedEnvController1,
+  GCPubSubScopedEnvController2,
+} from '../src/gc-pubsub-scoped-env.controller';
+
+describe('GC PubSub transport', () => {
+  let server;
+  let app: INestApplication;
+
+  describe('useAttributes=false', () => {
+    beforeEach(async () => {
+      await Test.createTestingModule({
+        controllers: [GCPubSubScopedEnvController2],
+      }).compile();
+      const module = await Test.createTestingModule({
+        controllers: [GCPubSubScopedEnvController1],
+      }).compile();
+
+      app = module.createNestApplication();
+      server = app.getHttpAdapter().getInstance();
+
+      app.connectMicroservice({
+        strategy: new GCPubSubServer({
+          client: {
+            apiEndpoint: 'localhost:8681',
+            projectId: 'microservice',
+          },
+          scopedEnvKey: 'foobar',
+        }),
+      });
+      await app.startAllMicroservices();
+      await app.init();
+    });
+
+    it('/POST', () => {
+      request(server).post('/rpc').expect(200, 'scoped RPC');
+    });
+
+    it('/POST (event notification)', (done) => {
+      request(server)
+        .post('/notify')
+        .end(() => {
+          setTimeout(() => {
+            expect(GCPubSubScopedEnvController1.IS_NOTIFIED).to.be.true;
+            expect(GCPubSubScopedEnvController2.IS_NOTIFIED).to.be.false;
+            done();
+          }, 1000);
+        });
+    });
+
+    afterEach(async () => {
+      await app.close();
+    });
+  });
+});

--- a/tests/src/gc-pubsub-scoped-env.controller.ts
+++ b/tests/src/gc-pubsub-scoped-env.controller.ts
@@ -1,0 +1,92 @@
+import {
+  Controller,
+  HttpCode,
+  OnApplicationShutdown,
+  Post,
+} from '@nestjs/common';
+import {
+  ClientProxy,
+  EventPattern,
+  MessagePattern,
+} from '@nestjs/microservices';
+import { GCPubSubClient } from '../../lib';
+import { Observable } from 'rxjs';
+
+@Controller()
+export class GCPubSubScopedEnvController1 implements OnApplicationShutdown {
+  static IS_NOTIFIED = false;
+
+  client: ClientProxy;
+
+  constructor() {
+    this.client = new GCPubSubClient({
+      client: {
+        apiEndpoint: 'localhost:8681',
+        projectId: 'microservice',
+      },
+      replyTopic: 'default_reply_topic',
+      replySubscription: 'default_reply_subscription',
+      scopedEnvKey: 'foobar',
+    });
+  }
+
+  onApplicationShutdown(signal?: string) {
+    return this.client.close();
+  }
+
+  @Post()
+  @HttpCode(200)
+  call() {
+    return this.client.send({ cmd: 'rpc' }, {});
+  }
+
+  @Post('notify')
+  async sendNotification(): Promise<any> {
+    return this.client.emit<{ notification: boolean; id: string }>(
+      'notification',
+      { notification: true, id: 'id' },
+    );
+  }
+
+  @MessagePattern({ cmd: 'rpc' })
+  rpc(): string {
+    return 'scoped RPC';
+  }
+
+  @EventPattern('notification')
+  eventHandler(data: { notification: boolean; id: string }) {
+    GCPubSubScopedEnvController1.IS_NOTIFIED = data.notification;
+  }
+}
+
+@Controller()
+export class GCPubSubScopedEnvController2 implements OnApplicationShutdown {
+  static IS_NOTIFIED = false;
+
+  client: ClientProxy;
+
+  constructor() {
+    this.client = new GCPubSubClient({
+      client: {
+        apiEndpoint: 'localhost:8681',
+        projectId: 'microservice',
+      },
+      replyTopic: 'default_reply_topic',
+      replySubscription: 'default_reply_subscription',
+    });
+  }
+
+  onApplicationShutdown(signal?: string) {
+    return this.client.close();
+  }
+
+  @MessagePattern({ cmd: 'rpc' })
+  rpc(): string {
+    return 'RPC';
+  }
+
+  @EventPattern('notification')
+  eventHandler(data: { notification: boolean; id: string }) {
+    GCPubSubScopedEnvController2.IS_NOTIFIED = data.notification;
+  }
+}


### PR DESCRIPTION
Hi,

I'd like to suggest something we're already using in our team: the ability to scope topics and subscriptions.
The aim is to avoid losing messages when several people are working on the same code base (thus subscribing the same handlers to the same subscriptions).
The change introduces a `scopedEnvKey` that prefixes topics and subscriptions. Messages cannot be consumed anymore by any handlers on the team.