### PR TITLE
fix: create topic if not exists on client connect

### DIFF
--- a/lib/gc-pubsub.client.ts
+++ b/lib/gc-pubsub.client.ts
@@ -102,7 +102,9 @@ export class GCPubSubClient extends ClientProxy {
 
     this.topic = this.client.topic(this.topicName, this.publisherConfig);
 
-    if (this.checkExistence) {
+    if (this.init) {
+      await this.createIfNotExists(this.topic.create.bind(this.topic));
+    } else if (this.checkExistence) {
       const [topicExists] = await this.topic.exists();
 
       if (!topicExists) {


### PR DESCRIPTION
### Current behavior:
Calling `client.connect()` inside `onApplicationBootstrap` hook, makes app fails if topic not exists

```typescript
async onApplicationBootstrap() {
    await this.client.connect();
}
```

### Expected behavior:
The topic should be created without issues...