### PR TITLE
chore: bump reflect-metadata in peer dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -69,7 +69,7 @@
     "@nestjs/common": "^10.0.0",
     "@nestjs/core": "^10.0.0",
     "@nestjs/microservices": "^10.0.0",
-    "reflect-metadata": "^0.1.13",
+    "reflect-metadata": "^0.1.13 || ^0.2.2",
     "rxjs": "^7.8.1"
   },
   "lint-staged": {


### PR DESCRIPTION
[The issue](https://github.com/p-fedyukovich/nestjs-google-pubsub-microservice/issues/44)