### PR TITLE
fix: p-fedyukovich/nestjs-google-pubsub-microservice#43

### DIFF
--- a/lib/gc-pubsub.server.spec.ts
+++ b/lib/gc-pubsub.server.spec.ts
@@ -183,6 +183,23 @@ describe('GCPubSubServer', () => {
       });
       expect(handler.calledOnce).to.be.true;
     });
+
+    it('should return undefined when data is not in JSON format', async () => {
+      const result = await server.handleMessage({
+        ackId: 'id',
+        // @ts-ignore
+        publishTime: new Date(),
+        attributes: {},
+        id: 'id',
+        received: 0,
+        deliveryAttempt: 1,
+        ack: () => {},
+        modAck: () => {},
+        nack: () => {},
+        data: Buffer.from('text'),
+      });
+      expect(result).to.be.undefined;
+    });
   });
 
   describe('sendMessage', () => {

--- a/lib/gc-pubsub.server.ts
+++ b/lib/gc-pubsub.server.ts
@@ -155,7 +155,15 @@ export class GCPubSubServer
 
   public async handleMessage(message: Message) {
     const { data, attributes } = message;
-    const rawMessage = JSON.parse(data.toString());
+    let rawMessage;
+    try {
+      rawMessage = JSON.parse(data.toString());
+    } catch (error: any) {
+      this.logger.error(
+        `Unsupported JSON message data format for message '${message.id}'`,
+      );
+      return;
+    }
 
     let packet;
     if (attributes.pattern) {


### PR DESCRIPTION
#43 
We got issue if someone publish bad message format (without proper JSON) and make the nestjs server crash

Add a try catch on the `JSON.parse` and log error and stop the processing

Let me know if you have better solution / logging message proposition @p-fedyukovich